### PR TITLE
Complete coil tools

### DIFF
--- a/src/mephit_conf.f90
+++ b/src/mephit_conf.f90
@@ -20,7 +20,7 @@ module mephit_conf
     pres_prof_eps, pres_prof_par, pres_prof_geqdsk, &
     curr_prof_ps, curr_prof_rot, curr_prof_geqdsk, &
     q_prof_flux, q_prof_rot, q_prof_geqdsk, &
-    vac_src_nemov, vac_src_gpec, vac_src_fourier, &
+    vac_src_nemov, vac_src_gpec, vac_src_fourier, vac_src_vecpot, &
     currn_model_mhd, currn_model_kilca, &
     refinement_scheme_geometric, refinement_scheme_gaussian, &
     transition_func_none, transition_func_heaviside, transition_func_smooth
@@ -51,6 +51,7 @@ module mephit_conf
   integer, parameter :: vac_src_nemov = 0   !< vacuum field perturbation from Viktor Nemov's code
   integer, parameter :: vac_src_gpec = 1    !< vacuum field perturbation from GPEC
   integer, parameter :: vac_src_fourier = 2 !< vacuum field perturbation from precomputed Fourier modes
+  integer, parameter :: vac_src_vecpot = 3  !< vacuum field perturbation from precomputed Fourier modes of vector potential
 
   integer, parameter :: currn_model_mhd = 0    !< response current from iMHD model
   integer, parameter :: currn_model_kilca = 1  !< response current from KiLCA model
@@ -91,8 +92,8 @@ module mephit_conf
     integer :: q_prof = q_prof_rot
 
     !> Source of vacuum field perturbation. Possible values are #vac_src_nemov,
-    !> #vac_src_gpec, and #vac_src_fourier (default).
-    integer :: vac_src = vac_src_fourier
+    !> #vac_src_gpec, #vac_src_fourier, and #vac_src_vecpot (default).
+    integer :: vac_src = vac_src_vecpot
 
     !> Method to compute response current. Possible values are #currn_model_mhd (default)
     !> and #currn_model_kilca.

--- a/src/mephit_conf.f90
+++ b/src/mephit_conf.f90
@@ -92,8 +92,8 @@ module mephit_conf
     integer :: q_prof = q_prof_rot
 
     !> Source of vacuum field perturbation. Possible values are #vac_src_nemov,
-    !> #vac_src_gpec, #vac_src_fourier, and #vac_src_vecpot (default).
-    integer :: vac_src = vac_src_vecpot
+    !> #vac_src_gpec, #vac_src_fourier (default), and #vac_src_vecpot.
+    integer :: vac_src = vac_src_fourier
 
     !> Method to compute response current. Possible values are #currn_model_mhd (default)
     !> and #currn_model_kilca.

--- a/src/mephit_pert.f90
+++ b/src/mephit_pert.f90
@@ -741,7 +741,7 @@ contains
 
   subroutine L1_sum_poloidal_modes(polmodes, elem)
     use mephit_util, only: imun
-    use mephit_mesh, only: mesh, cache
+    use mephit_mesh, only: mesh
     type(polmodes_t), intent(in) :: polmodes
     type(L1_t), intent(inout) :: elem
     integer :: kf, kp, kpoi, m
@@ -1032,34 +1032,53 @@ contains
   end subroutine read_Bnvac_GPEC
 
   subroutine compute_Bnvac(Bn)
-    use coil_tools, only: read_currents, read_Bnvac_Fourier
-    use mephit_conf, only: conf, logger, vac_src_nemov, vac_src_gpec, vac_src_fourier
+    use coil_tools, only: read_currents, read_Bnvac_Fourier, read_Anvac_Fourier, &
+      gauged_Anvac_from_Bnvac, sum_coils_gauge_single_mode_Anvac
+    use mephit_conf, only: conf, logger, vac_src_nemov, vac_src_gpec, vac_src_fourier, &
+      vac_src_vecpot
     use mephit_mesh, only: mesh
     type(RT0_t), intent(inout) :: Bn
-    integer :: nR, nZ, kedge, k
+    integer :: nR, nZ, nphi, ncoil, nmax, kedge, k
     real(dp) :: Rmin, Rmax, Zmin, Zmax, edge_perp(3)
     real(dp), dimension(:), allocatable :: Ic
-    complex(dp), dimension(:, :), allocatable :: Bn_R, Bn_Z
+    complex(dp), dimension(:, :), allocatable :: BnR, BnZ, gauged_AnR, gauged_AnZ
+    complex(dp), dimension(:, :, :, :), allocatable :: AnR, Anphi, AnZ, dAnphi_dR, dAnphi_dZ
     complex(dp) :: Bn_splined(3)
 
     ! initialize vacuum field
     select case (conf%vac_src)
     case (vac_src_nemov)
-      call read_Bnvac_Nemov(nR, nZ, Rmin, Rmax, Zmin, Zmax, Bn_R, Bn_Z)
+      call read_Bnvac_Nemov(nR, nZ, Rmin, Rmax, Zmin, Zmax, BnR, BnZ)
+      call gauged_Anvac_from_Bnvac(BnR, BnZ, conf%n, Rmin, Rmax, nR, Zmin, Zmax, nZ, &
+        gauged_AnR, gauged_AnZ)
+      deallocate(BnR, BnZ)
     case (vac_src_gpec)
-      call read_Bnvac_GPEC(nR, nZ, Rmin, Rmax, Zmin, Zmax, Bn_R, Bn_Z)
+      call read_Bnvac_GPEC(nR, nZ, Rmin, Rmax, Zmin, Zmax, BnR, BnZ)
+      call gauged_Anvac_from_Bnvac(BnR, BnZ, conf%n, Rmin, Rmax, nR, Zmin, Zmax, nZ, &
+        gauged_AnR, gauged_AnZ)
+      deallocate(BnR, BnZ)
     case (vac_src_fourier)
       call read_currents(conf%currents_file, Ic)
       call read_Bnvac_Fourier(conf%coil_file, conf%n, conf%Biot_Savart_prefactor * Ic, &
-        nR, nZ, Rmin, Rmax, Zmin, Zmax, Bn_R, Bn_Z)
-      deallocate(Ic)
+        nR, nZ, Rmin, Rmax, Zmin, Zmax, BnR, BnZ)
+      call gauged_Anvac_from_Bnvac(BnR, BnZ, conf%n, Rmin, Rmax, nR, Zmin, Zmax, nZ, &
+        gauged_AnR, gauged_AnZ)
+      deallocate(BnR, BnZ, Ic)
+    case (vac_src_vecpot)
+      call read_currents(conf%currents_file, Ic)
+      call read_Anvac_Fourier(conf%coil_file, ncoil, nmax, Rmin, Rmax, Zmin, Zmax, &
+        nR, nphi, nZ, AnR, Anphi, AnZ, dAnphi_dR, dAnphi_dZ)
+      call sum_coils_gauge_single_mode_Anvac(AnR, Anphi, AnZ, dAnphi_dR, dAnphi_dZ, &
+        Ic, conf%n, Rmin, Rmax, nR, Zmin, Zmax, nZ, gauged_AnR, gauged_AnZ)
+      deallocate(AnR, Anphi, AnZ, dAnphi_dR, dAnphi_dZ, Ic)
     case default
       write (logger%msg, '("unknown vacuum field source selection", i0)') conf%vac_src
       if (logger%err) call logger%write_msg
       error stop
     end select
-    call vector_potential_single_mode(conf%n, nR, nZ, Rmin, Rmax, Zmin, Zmax, Bn_R, Bn_Z)
-    deallocate(Bn_R, Bn_Z)
+    call vector_potential_single_mode(conf%n, nR, nZ, Rmin, Rmax, Zmin, Zmax, &
+      gauged_AnR, gauged_AnZ)
+    deallocate(gauged_AnR, gauged_AnZ)
     ! project to finite elements
     Bn%DOF = (0d0, 0d0)
     do kedge = 1, mesh%nedge

--- a/src/mephit_pert.f90
+++ b/src/mephit_pert.f90
@@ -1069,7 +1069,8 @@ contains
       call read_Anvac_Fourier(conf%coil_file, ncoil, nmax, Rmin, Rmax, Zmin, Zmax, &
         nR, nphi, nZ, AnR, Anphi, AnZ, dAnphi_dR, dAnphi_dZ)
       call sum_coils_gauge_single_mode_Anvac(AnR, Anphi, AnZ, dAnphi_dR, dAnphi_dZ, &
-        Ic, conf%n, Rmin, Rmax, nR, Zmin, Zmax, nZ, gauged_AnR, gauged_AnZ)
+        conf%Biot_Savart_prefactor * Ic, conf%n, Rmin, Rmax, nR, Zmin, Zmax, nZ, &
+        gauged_AnR, gauged_AnZ)
       deallocate(AnR, Anphi, AnZ, dAnphi_dR, dAnphi_dZ, Ic)
     case default
       write (logger%msg, '("unknown vacuum field source selection", i0)') conf%vac_src


### PR DESCRIPTION
### **User description**
Biot-Savart development is finished for now. The singularities appearing in the derivatives of the vector potential formulation will be investigated later, so the default is still the magnetic field computation.


___

### **PR Type**
Enhancement


___

### **Description**
- Add support for gauged vector potential computation with singularity avoidance

- Introduce new vacuum source option `vac_src_vecpot` for precomputed vector potential Fourier modes

- Fix Biot-Savart prefactor application in vacuum field calculations

- Update vacuum field computation to use gauged vector potential approach


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Read vacuum source"] --> B{"Source type"}
  B -- "Nemov/GPEC/Fourier" --> C["Compute Bn field"]
  B -- "vecpot (new)" --> D["Read An Fourier modes"]
  C --> E["Convert to gauged An"]
  D --> F["Sum coils and gauge"]
  E --> G["Vector potential single mode"]
  F --> G
  G --> H["Project to finite elements"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mephit_conf.f90</strong><dd><code>Add vector potential vacuum source configuration option</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/mephit_conf.f90

<ul><li>Add new parameter <code>vac_src_vecpot</code> for vector potential vacuum source<br> <li> Update documentation for <code>vac_src</code> configuration option<br> <li> Export <code>vac_src_vecpot</code> as public parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/MEPHIT/pull/17/files#diff-2d606095877a0e9529c874254f2cb33917f17521e1fa486ea84c5fa2fdab8b26">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mephit_pert.f90</strong><dd><code>Implement gauged vector potential computation for vacuum fields</code></dd></summary>
<hr>

src/mephit_pert.f90

<ul><li>Import new functions <code>read_Anvac_Fourier</code>, <code>gauged_Anvac_from_Bnvac</code>, and <br><code>sum_coils_gauge_single_mode_Anvac</code><br> <li> Add <code>vac_src_vecpot</code> case for reading precomputed vector potential <br>Fourier modes<br> <li> Convert all vacuum source paths to use gauged vector potential <br>approach<br> <li> Apply <code>Biot_Savart_prefactor</code> to coil currents in Fourier and vecpot <br>cases<br> <li> Remove unused <code>cache</code> import from <code>mephit_mesh</code></ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/MEPHIT/pull/17/files#diff-a9aa2a9da6909f5fec0a27d093e09289a7923babb9998327b0521091749d0731">+31/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

