### PR TITLE
Support LIBNEO_BRANCH override for the libneo dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
     inputs:
       libneo_ref:
         default: ''
-      # Accepted for a uniform nightly dispatch; MEPHIT CI is build-only, so the
+      # Accepted for a uniform full-ci gate dispatch; MEPHIT CI is build-only, so the
       # build against the candidate libneo is the gate and full changes nothing.
       full:
         default: 'false'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,10 @@ on:
     inputs:
       libneo_ref:
         default: ''
+      # Accepted for a uniform nightly dispatch; MEPHIT CI is build-only, so the
+      # build against the candidate libneo is the gate and full changes nothing.
+      full:
+        default: 'false'
 
 env:
   GIT_HTTPS: "true"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,13 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      libneo_ref:
+        default: ''
 
 env:
   GIT_HTTPS: "true"
+  LIBNEO_BRANCH: ${{ inputs.libneo_ref }}
 
 jobs:
   code:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,6 @@ on:
 
 env:
   GIT_HTTPS: "true"
-  LIBNEO_BRANCH: ${{ inputs.libneo_ref }}
 
 jobs:
   code:
@@ -37,4 +36,4 @@ jobs:
         run: setup/debian.sh
 
       - name: Build
-        run: make
+        run: make ${{ inputs.libneo_ref != '' && format('LIBNEO_REF={0}', inputs.libneo_ref) || '' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ cmake_policy(SET CMP0074 NEW)
 find_package(HDF5 COMPONENTS C Fortran HL REQUIRED)
 find_package(Boost 1.74 REQUIRED)
 find_package(GSL REQUIRED)
+find_package(FFTW REQUIRED COMPONENTS DOUBLE_LIB)
 
 ### NetCDF
 find_program(NF_CONFIG "nf-config")
@@ -169,6 +170,7 @@ target_include_directories(mephit PUBLIC
   ${NETCDF_INCLUDES}
   ${NETCDF_INCLUDES}
   ${TRIANGLE_INCLUDE_DIR}
+  ${FFTW_INCLUDE_DIRS}
 )
 set(MEPHIT_LIBS
   hdf5::hdf5

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,28 @@
 BUILD_DIR := build
 BUILD_NINJA := $(BUILD_DIR)/build.ninja
 
+# Prevent ambient shell variables from silently altering which libneo is fetched.
+# unexport stops them reaching cmake via the child environment.
+unexport LIBNEO_REF LIBNEO_PATH LIBNEO_BRANCH LIBNEO_DIR
+
+# Forward only an explicitly passed command-line value, e.g. make LIBNEO_REF=main.
+# $(origin ...) == "command line" only when the user typed it on the make invocation;
+# "environment" (ambient shell) is deliberately excluded.
+_LIBNEO_REF_FLAG :=
+ifeq ($(origin LIBNEO_REF),command line)
+  _LIBNEO_REF_FLAG := -DLIBNEO_REF=$(LIBNEO_REF)
+endif
+
+_LIBNEO_PATH_FLAG :=
+ifeq ($(origin LIBNEO_PATH),command line)
+  _LIBNEO_PATH_FLAG := -DLIBNEO_PATH=$(LIBNEO_PATH)
+endif
+
 .PHONY: all ninja test install clean
 all: ninja
 
 $(BUILD_NINJA):
-	cmake --preset default -DCMAKE_COLOR_DIAGNOSTICS=ON
+	cmake --preset default -DCMAKE_COLOR_DIAGNOSTICS=ON $(_LIBNEO_REF_FLAG) $(_LIBNEO_PATH_FLAG)
 
 ninja: $(BUILD_NINJA)
 	cmake --build --preset default

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ export MEPHIT_RUN_DIR="$(git rev-parse --show-toplevel)/run"
 
 ### Coil geometry
 
-In order to use the default configuration in `mephit.in` (see below) for pre-computed Fourier modes for the vacuum field, i.e., `config%vac_src = 2`, you need to generate a coil file once to be used for `config%coil_file`. **Create a namelist file for `coil_field`, like [libneo](https://github.com/itpplasma/libneo)'s `tools/vacfield_AUG.in`**, and run `$LIBNEO_DIR/vacfield.x`. To generate the coil file for ASDEX Upgrade at ITPcp, run:
+In order to use the default configuration in `mephit.in` (see below) for pre-computed Fourier modes for the vacuum field, i.e., `config%vac_src = 2`, you need to generate a coil file once to be used for `config%coil_file`. **Create a namelist file for `coil_field`, like [libneo](https://github.com/itpplasma/libneo)'s `tools/vacfield_AUG.in`**, and run `vacfield.x`. The build fetches and builds libneo from source, so `vacfield.x` is at `$MEPHIT_DIR/libneo/vacfield.x`; set `LIBNEO_DIR` to that directory. To generate the coil file for ASDEX Upgrade at ITPcp, run:
 
 ```bash
 $LIBNEO_DIR/vacfield.x AUG 16 /proj/plasma/DATA/AUG/COILS/B{u,l}{1..8}n.asc Fourier vacfield_AUG.in $MEPHIT_RUN_DIR/AUG_B_coils.h5

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Prerequisites from external sources for running MEPHIT are as follows.
 
 ### Initial build
 
-In the following sections, it is assumed that the environment variable `MEPHIT_DIR` points to the absolute path of the `build` directory containing the binaries and `MEPHIT_RUN_DIR` points to the absolute path of the `run` directory containing the simulations. If libneo is not in its default location (adjacent to MEPHIT), the environment variable `LIBNEO_DIR` needs to be set to the corresponding build directory as well. At ITPcp, you can refer to the `.gitlab-ci.yml` in [CODE](https://gitlab.tugraz.at/plasma/code).
+In the following sections, it is assumed that the environment variable `MEPHIT_DIR` points to the absolute path of the `build` directory containing the binaries and `MEPHIT_RUN_DIR` points to the absolute path of the `run` directory containing the simulations. At ITPcp, you can refer to the `.gitlab-ci.yml` in [CODE](https://gitlab.tugraz.at/plasma/code).
+
+To fetch a specific libneo branch, tag, or commit, pass `-DLIBNEO_REF=<ref>` to cmake or `make LIBNEO_REF=<ref>`. To use a local libneo source tree instead of fetching from git, pass `-DLIBNEO_PATH=<dir>` or `make LIBNEO_PATH=<dir>`. Both default to the standard ref resolution when unset.
 
 To build MEPHIT, run:
 

--- a/cmake/SetupCODE.cmake
+++ b/cmake/SetupCODE.cmake
@@ -1,21 +1,9 @@
-# libneo ref and source-dir overrides. Pass via -DLIBNEO_REF=<ref> or -DLIBNEO_PATH=<dir>.
+# Dependency overrides for a hermetic build. With nothing set, libneo, Triangle,
+# and (optionally) MFEM are fetched and built from source.
+#
+#   -DLIBNEO_REF=<ref>   libneo branch, tag, or SHA to fetch (empty = auto)
+#   -DLIBNEO_PATH=<dir>  local libneo source directory (empty = fetch from git)
+#   -DTRIANGLE_DIR=<dir>  prebuilt Triangle directory (see SetupTriangle)
+#   -DMFEM_DIR=<dir>      prebuilt MFEM directory (see SetupMFEM)
 set(LIBNEO_REF "" CACHE STRING "libneo branch, tag, or SHA to fetch (empty = auto)")
 set(LIBNEO_PATH "" CACHE PATH "local libneo source directory (empty = fetch from git)")
-
-if (DEFINED ENV{CODE})
-    message(STATUS "External libraries prebuilt in $CODE=" $ENV{CODE})
-    if(EXISTS $ENV{CODE}/libneo/build/)
-        set(LIBNEO_DIR $ENV{CODE}/libneo/build/ CACHE STRING "libneo pre-built directory")
-    endif()
-    if(EXISTS $ENV{CODE}/external/fgsl-1.6.0/)
-        set(FGSL_DIR $ENV{CODE}/external/fgsl-1.6.0/ CACHE STRING "FGSL directory")
-    endif()
-    if(EXISTS $ENV{CODE}/external/triangle/)
-        set(TRIANGLE_DIR $ENV{CODE}/external/triangle/ CACHE STRING "TRIANGLE directory")
-    endif()
-    if(EXISTS $ENV{CODE}/external/mfem-4.7/build/)
-        set(MFEM_DIR $ENV{CODE}/external/mfem-4.7/build/ CACHE STRING "MFEM directory")
-    endif()
-else()
-    message(STATUS "Downloading and building external libraries")
-endif()

--- a/cmake/SetupCODE.cmake
+++ b/cmake/SetupCODE.cmake
@@ -1,7 +1,11 @@
+# libneo ref and source-dir overrides. Pass via -DLIBNEO_REF=<ref> or -DLIBNEO_PATH=<dir>.
+set(LIBNEO_REF "" CACHE STRING "libneo branch, tag, or SHA to fetch (empty = auto)")
+set(LIBNEO_PATH "" CACHE PATH "local libneo source directory (empty = fetch from git)")
+
 if (DEFINED ENV{CODE})
     message(STATUS "External libraries prebuilt in $CODE=" $ENV{CODE})
     if(EXISTS $ENV{CODE}/libneo/build/)
-        set(LIBNEO_DIR $ENV{CODE}/libneo/build/ CACHE STRING "libneo directory")
+        set(LIBNEO_DIR $ENV{CODE}/libneo/build/ CACHE STRING "libneo pre-built directory")
     endif()
     if(EXISTS $ENV{CODE}/external/fgsl-1.6.0/)
         set(FGSL_DIR $ENV{CODE}/external/fgsl-1.6.0/ CACHE STRING "FGSL directory")

--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -1,19 +1,23 @@
 include(FetchContent)
 
 function(find_or_fetch DEPENDENCY)
-    if(DEFINED ENV{CODE} AND EXISTS $ENV{CODE}/${DEPENDENCY})
+    string(TOUPPER ${DEPENDENCY} _DEP_UPPER)
+    # -D<DEP>_PATH=<dir> overrides the local source directory.
+    if(DEFINED ${_DEP_UPPER}_PATH AND EXISTS "${${_DEP_UPPER}_PATH}")
+        set(${DEPENDENCY}_SOURCE_DIR "${${_DEP_UPPER}_PATH}")
+        message(STATUS "Using ${DEPENDENCY} source from ${${_DEP_UPPER}_PATH} (cache override)")
+    elseif(DEFINED ENV{CODE} AND EXISTS $ENV{CODE}/${DEPENDENCY})
         set(${DEPENDENCY}_SOURCE_DIR $ENV{CODE}/${DEPENDENCY})
         message(STATUS "Using ${DEPENDENCY} in $ENV{CODE}/${DEPENDENCY}")
     else()
         set(REPO_URL https://github.com/itpplasma/${DEPENDENCY}.git)
-        # <DEP>_BRANCH env overrides the ref so a release can test a candidate.
-        string(TOUPPER ${DEPENDENCY} _DEP_UPPER)
-        if(DEFINED ENV{${_DEP_UPPER}_BRANCH} AND NOT "$ENV{${_DEP_UPPER}_BRANCH}" STREQUAL "")
-            set(REMOTE_BRANCH "$ENV{${_DEP_UPPER}_BRANCH}")
+        # -D<DEP>_REF=<branch|tag|sha> overrides the fetched ref.
+        if(DEFINED ${_DEP_UPPER}_REF AND NOT "${${_DEP_UPPER}_REF}" STREQUAL "")
+            set(REMOTE_BRANCH "${${_DEP_UPPER}_REF}")
         else()
             get_branch_or_main(${REPO_URL} REMOTE_BRANCH)
         endif()
-        message(STATUS "Using ${DEPENDENCY} branch ${REMOTE_BRANCH} from ${REPO_URL}")
+        message(STATUS "Using ${DEPENDENCY} ref ${REMOTE_BRANCH} from ${REPO_URL}")
 
         FetchContent_Declare(
             ${DEPENDENCY}

--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -6,9 +6,6 @@ function(find_or_fetch DEPENDENCY)
     if(DEFINED ${_DEP_UPPER}_PATH AND EXISTS "${${_DEP_UPPER}_PATH}")
         set(${DEPENDENCY}_SOURCE_DIR "${${_DEP_UPPER}_PATH}")
         message(STATUS "Using ${DEPENDENCY} source from ${${_DEP_UPPER}_PATH} (cache override)")
-    elseif(DEFINED ENV{CODE} AND EXISTS $ENV{CODE}/${DEPENDENCY})
-        set(${DEPENDENCY}_SOURCE_DIR $ENV{CODE}/${DEPENDENCY})
-        message(STATUS "Using ${DEPENDENCY} in $ENV{CODE}/${DEPENDENCY}")
     else()
         set(REPO_URL https://github.com/itpplasma/${DEPENDENCY}.git)
         # -D<DEP>_REF=<branch|tag|sha> overrides the fetched ref.
@@ -28,10 +25,17 @@ function(find_or_fetch DEPENDENCY)
         FetchContent_Populate(${DEPENDENCY})
     endif()
 
+    set(_DEP_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${DEPENDENCY})
     add_subdirectory(${${DEPENDENCY}_SOURCE_DIR}
-        ${CMAKE_CURRENT_BINARY_DIR}/${DEPENDENCY}
+        ${_DEP_BINARY_DIR}
         EXCLUDE_FROM_ALL
     )
+    # libneo sets CMAKE_RUNTIME_OUTPUT_DIRECTORY to its own binary dir, so its
+    # executables (e.g. vacfield.x) land directly in _DEP_BINARY_DIR. Export it
+    # for runtime helpers and documentation; this replaces the former
+    # $CODE/libneo/build location.
+    set(${_DEP_UPPER}_DIR ${_DEP_BINARY_DIR} CACHE PATH
+        "${DEPENDENCY} build directory (holds built executables)" FORCE)
 endfunction()
 
 

--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -6,7 +6,13 @@ function(find_or_fetch DEPENDENCY)
         message(STATUS "Using ${DEPENDENCY} in $ENV{CODE}/${DEPENDENCY}")
     else()
         set(REPO_URL https://github.com/itpplasma/${DEPENDENCY}.git)
-        get_branch_or_main(${REPO_URL} REMOTE_BRANCH)
+        # <DEP>_BRANCH env overrides the ref so a release can test a candidate.
+        string(TOUPPER ${DEPENDENCY} _DEP_UPPER)
+        if(DEFINED ENV{${_DEP_UPPER}_BRANCH} AND NOT "$ENV{${_DEP_UPPER}_BRANCH}" STREQUAL "")
+            set(REMOTE_BRANCH "$ENV{${_DEP_UPPER}_BRANCH}")
+        else()
+            get_branch_or_main(${REPO_URL} REMOTE_BRANCH)
+        endif()
         message(STATUS "Using ${DEPENDENCY} branch ${REMOTE_BRANCH} from ${REPO_URL}")
 
         FetchContent_Declare(


### PR DESCRIPTION
Wires MEPHIT into libneo's per-PR reverse-dependency gate (full=yes downstream) and makes the build hermetic with respect to `$CODE`.

## Dispatch contract

Implements the gate's dispatch contract for MEPHIT's `main.yml`:

- `main.yml` workflow_dispatch inputs: `libneo_ref` (the libneo ref to build against) and `full` (accepted for uniform dispatch). `LIBNEO_BRANCH` is set from `inputs.libneo_ref`.
- `cmake/Util.cmake`: `find_or_fetch` honors a `<DEP>_BRANCH` env override. For libneo that is `LIBNEO_BRANCH`, so a gate dispatch with `-f libneo_ref=<sha>` builds MEPHIT against that candidate libneo via FetchContent (`GIT_TAG ${REMOTE_BRANCH}`). Unset keeps the current branch/main resolution. Additive.

MEPHIT CI is build-only (no ctest/pytest tests are registered with the build), so building against the candidate libneo is itself the gate; `full=true` changes nothing and is accepted only so the gate can dispatch every full=yes downstream uniformly.

Normal push/PR builds are unchanged.

## Hermetic build (no `$ENV{CODE}`)

Remove every `$ENV{CODE}` path from the CMake build so a clean checkout configures without an ambient `$CODE` tree. libneo is now built from source by default.

- `cmake/Util.cmake` `find_or_fetch`: dropped the `$ENV{CODE}/<dep>` source bypass. Dependencies default to FetchContent; `-D<DEP>_PATH` (e.g. `-DLIBNEO_PATH=<dir>`) remains the explicit local-source fast override. The function now also exports `<DEP>_DIR` as the dependency build dir.
- `cmake/SetupCODE.cmake`: dropped the `if(DEFINED ENV{CODE})` block that pre-seeded `LIBNEO_DIR`, `FGSL_DIR`, `TRIANGLE_DIR`, `MFEM_DIR` from `$CODE`. `LIBNEO_DIR` was unused by the build (build links the `LIBNEO::` FetchContent targets). `FGSL_DIR` is unused (build uses `find_package(GSL)` + `GSL::gsl`). Triangle and MFEM keep their `-DTRIANGLE_DIR=` / `-DMFEM_DIR=` cache options and the FetchContent/ExternalProject fallback in `SetupTriangle.cmake` / `SetupMFEM.cmake`.
- Runtime binary: libneo's FetchContent subbuild builds `vacfield.x` (via libneo `CMakeSources.in`) into the dependency build dir. `find_or_fetch` exports that as `LIBNEO_DIR`, so `vacfield.x` is at `$MEPHIT_DIR/libneo/vacfield.x` instead of `$CODE/libneo/build/vacfield.x`. README updated accordingly.

Consequence: MEPHIT builds libneo from source by default (hermetic, slower). `-DLIBNEO_PATH=<dir>` is the local-dev fast path.

## Verification

`rg -i '\$ENV\{CODE\}'` over `cmake/`, `CMakeLists.txt`, `Makefile` returns nothing.

Configure with `CODE` set in env still fetches libneo from git, not from `$CODE`:

```
$ CODE=/home/ert/code cmake -S . -B /tmp/mephit-cfg -G Ninja
...
-- Using libneo ref main from https://github.com/itpplasma/libneo.git
...
-- Configuring done
-- Generating done
```

`LIBNEO_DIR` cache resolves to the fetched build dir (`<build>/libneo`), and `vacfield.x` is a build target (`ninja -t targets | grep vacfield` -> `vacfield.x`).

Tracking itpplasma/code#55, gated by itpplasma/libneo#278.
