### PR TITLE
Allow external libneo_ref trigger in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,18 @@ on:
   pull_request:
     branches: [ "main" ]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually, and lets an upstream libneo
+  # release dispatch it against a candidate ref.
   workflow_dispatch:
+    inputs:
+      libneo_ref:
+        description: libneo branch or tag to build against
+        required: false
+        default: ''
 
 env:
   GIT_HTTPS: "true"
+  LIBNEO_REF: ${{ inputs.libneo_ref }}
 
 jobs:
   code:


### PR DESCRIPTION
**Merge after #19 (the resolver PR).** The `LIBNEO_REF` env added here is inert until that resolver PR lands and reads it; merging this first is harmless but does nothing.

Adds a `libneo_ref` `workflow_dispatch` input mapped to `LIBNEO_REF`, so an upstream libneo release can dispatch this CI to build MEPHIT against a candidate ref (branch, tag or commit). Empty on push/PR, so normal builds keep the committed default.