### PR TITLE
Replace GSL Bessel I_n with fortnum (1/5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ include(FetchContent)
 if(NOT TARGET fortnum)
   FetchContent_Declare(fortnum
     GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-    GIT_TAG v0.1.0
+    GIT_TAG 92de6e949a772cfffc73bb5295fe5e2b056b9c18
   )
   FetchContent_MakeAvailable(fortnum)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ find_or_fetch(libneo)
 include(FetchContent)
 if(NOT TARGET fortnum)
   FetchContent_Declare(fortnum
-    GIT_REPOSITORY git@github.com:lazy-fortran/fortnum.git
+    GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
     GIT_TAG a7faa3c
   )
   FetchContent_MakeAvailable(fortnum)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,17 @@ endif()
 include(Util)
 find_or_fetch(libneo)
 
+### fortnum: numerical core replacing the former GSL routines. libneo may pull
+### fortnum in transitively, so guard against declaring the target twice.
+include(FetchContent)
+if(NOT TARGET fortnum)
+  FetchContent_Declare(fortnum
+    GIT_REPOSITORY git@github.com:lazy-fortran/fortnum.git
+    GIT_TAG a7faa3c
+  )
+  FetchContent_MakeAvailable(fortnum)
+endif()
+
 ### Project source files
 # SuiteSparse
 set(SUITESPARSE_SRC_FILES
@@ -152,7 +163,7 @@ if(WITH_MFEM)
   )
 endif()
 set_source_files_properties(src/mephit_run.c ${MEPHIT_C_SRC_FILES} ${MEPHIT_CPP_SRC_FILES}
-	PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -DREAL=double -I${TRIANGLE_INCLUDE_DIR} -I${SUITESPARSE_INCLUDE_DIRS} -L${TRIANGLE_LIB_DIR}")
+	PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -DREAL=double -I${TRIANGLE_INCLUDE_DIR} -I${SUITESPARSE_INCLUDE_DIRS} -I${fortnum_SOURCE_DIR}/include -L${TRIANGLE_LIB_DIR}")
 
 
 ### Define library
@@ -176,6 +187,7 @@ set(MEPHIT_LIBS
   hdf5::hdf5_fortran
   hdf5::hdf5_hl_fortran
   GSL::gsl
+  fortnum
   BLAS::BLAS
   LAPACK::LAPACK
   ${FFTW_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ include(FetchContent)
 if(NOT TARGET fortnum)
   FetchContent_Declare(fortnum
     GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-    GIT_TAG a7faa3c
+    GIT_TAG v0.1.0
   )
   FetchContent_MakeAvailable(fortnum)
 endif()

--- a/src/mephit_pert.f90
+++ b/src/mephit_pert.f90
@@ -1,7 +1,6 @@
 module mephit_pert
 
   use iso_fortran_env, only: dp => real64
-  use iso_c_binding, only: c_int, c_double
 
   implicit none
 
@@ -35,17 +34,6 @@ module mephit_pert
       type(field_cache_t), intent(in) :: f
       complex(dp) :: vector_element_projection
     end function vector_element_projection
-  end interface
-
-  interface
-    function gsl_sf_bessel_icn_array(nmin, nmax, x, result_array) &
-      bind(C, name='gsl_sf_bessel_In_array')
-      import :: c_int, c_double
-      integer(c_int), intent(in), value :: nmin, nmax
-      real(c_double), intent(in), value :: x
-      real(c_double), intent(inout), dimension(nmax - nmin + 1) :: result_array
-      integer(c_int) :: gsl_sf_bessel_icn_array
-    end function gsl_sf_bessel_icn_array
   end interface
 
   type :: L1_t
@@ -1427,21 +1415,21 @@ contains
   !> field
   subroutine kilca_vacuum_fourier(tor_mode, pol_mode, R_0, r, vac_coeff, &
     B_rad, B_pol, B_tor)
-    use mephit_conf, only: logger
     use mephit_util, only: imun
+    use fortnum_special, only: bessel_in_array
     integer, intent(in) :: tor_mode, pol_mode
     real(dp), intent(in) :: R_0, r
     complex(dp), intent(in) :: vac_coeff
     complex(dp), intent(out) :: B_rad, B_pol, B_tor
-    real(c_double) :: I_m(-1:1), k_z_r
-    integer(c_int) :: status
+    real(dp) :: I_n(0:abs(pol_mode) + 1), I_m(-1:1), k_z_r
 
     k_z_r = tor_mode / R_0 * r
-    status = gsl_sf_bessel_icn_array(abs(pol_mode)-1, abs(pol_mode)+1, k_z_r, I_m)
-    if (status /= 0 .and. logger%err) then
-      write (logger%msg, '("gsl_sf_bessel_In_array returned error ", i0)') status
-      call logger%write_msg
-    end if
+    ! fortnum fills I_n(0:nmax) with I_0..I_nmax; recover the order |pol_mode|-1
+    ! (which is -1 for pol_mode = 0) via the symmetry I_{-n}(x) = I_n(x).
+    call bessel_in_array(abs(pol_mode) + 1, k_z_r, I_n)
+    I_m(-1) = I_n(abs(abs(pol_mode) - 1))
+    I_m(0) = I_n(abs(pol_mode))
+    I_m(1) = I_n(abs(pol_mode) + 1)
     B_rad = 0.5d0 * (I_m(-1) + I_m(1)) * vac_coeff
     B_pol = imun * pol_mode / k_z_r * I_m(0) * vac_coeff
     B_tor = imun * I_m(0) * vac_coeff


### PR DESCRIPTION
## Merge order

Stack sequence: #29 -> #30 -> #31 -> #32 -> #33.

Each PR is now based on main individually, so its diff is cumulative against main and shares code with its stack neighbors. Merge in the sequence above. Once a predecessor merges into main, the next PR rebases onto it and its diff shrinks to its own increment.

---

First in a five-PR stack migrating MEPHIT off GSL (and FFTW) onto the fortnum numerical core. Merged in order, the stack composes to the full migration; this PR wires fortnum via CMake FetchContent and moves the modified-Bessel call site in mephit_pert.

Dependency removed: the gsl_sf_bessel_In_array C binding. fortnum's bessel_in_array fills I_0..I_nmax in one pass; the orders |m|-1, |m|, |m|+1 are recovered with the symmetry I_{-n}(x) = I_n(x), so pol_mode = 0 maps order -1 to I_1. fortnum is declared with FetchContent at the pinned tag 92de6e9, guarded by if(NOT TARGET fortnum) because libneo also pulls it in transitively. The fortnum include dir is added for the C/C++ sources and the fortnum target is linked. GSL stays linked until the remaining call sites move over in the later PRs of this stack.

## Verification

Configure and build the shared library at this tip (out-of-source build):

```
$ cmake -S . -B build -G Ninja
...
-- Configuring done (9.6s)
-- Generating done (0.1s)
$ cmake --build build --target mephit
[7/7] Linking CXX shared library lib/libmephit.so
```

fortnum is pinned at the required tag:

```
$ git -C build/_deps/fortnum-src rev-parse HEAD
92de6e949a772cfffc73bb5295fe5e2b056b9c18
```

The GSL Bessel symbol is gone and fortnum's routine is now linked:

```
$ nm -DC build/lib/libmephit.so | grep -i 'gsl_sf_bessel\|bessel_in_array'
0000000000110740 T __fortnum_special_bessel_MOD_bessel_in_array
```

Note: the .x executables do not link at this tip, and they also do not link on main: find_package(FFTW) is never called, so the FFTW_LIBRARIES link variable is empty and the FFTW symbols pulled in by src/fftw3.f90 are unresolved at the executable link step. PR 4 of this stack removes that FFTW usage and the executables link. The shared library, the verifiable artifact for this aspect, builds.



Note: fortnum pin updated to current main (92de6e9) after a fortnum history rewrite; old shas no longer resolve.
