### PR TITLE
Replace GSL quadrature and Levin sum in hyper1F1 with fortnum (2/5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ include(FetchContent)
 if(NOT TARGET fortnum)
   FetchContent_Declare(fortnum
     GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-    GIT_TAG v0.1.0
+    GIT_TAG 92de6e949a772cfffc73bb5295fe5e2b056b9c18
   )
   FetchContent_MakeAvailable(fortnum)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ find_or_fetch(libneo)
 include(FetchContent)
 if(NOT TARGET fortnum)
   FetchContent_Declare(fortnum
-    GIT_REPOSITORY git@github.com:lazy-fortran/fortnum.git
+    GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
     GIT_TAG a7faa3c
   )
   FetchContent_MakeAvailable(fortnum)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,17 @@ endif()
 include(Util)
 find_or_fetch(libneo)
 
+### fortnum: numerical core replacing the former GSL routines. libneo may pull
+### fortnum in transitively, so guard against declaring the target twice.
+include(FetchContent)
+if(NOT TARGET fortnum)
+  FetchContent_Declare(fortnum
+    GIT_REPOSITORY git@github.com:lazy-fortran/fortnum.git
+    GIT_TAG a7faa3c
+  )
+  FetchContent_MakeAvailable(fortnum)
+endif()
+
 ### Project source files
 # SuiteSparse
 set(SUITESPARSE_SRC_FILES
@@ -152,7 +163,7 @@ if(WITH_MFEM)
   )
 endif()
 set_source_files_properties(src/mephit_run.c ${MEPHIT_C_SRC_FILES} ${MEPHIT_CPP_SRC_FILES}
-	PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -DREAL=double -I${TRIANGLE_INCLUDE_DIR} -I${SUITESPARSE_INCLUDE_DIRS} -L${TRIANGLE_LIB_DIR}")
+	PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -DREAL=double -I${TRIANGLE_INCLUDE_DIR} -I${SUITESPARSE_INCLUDE_DIRS} -I${fortnum_SOURCE_DIR}/include -L${TRIANGLE_LIB_DIR}")
 
 
 ### Define library
@@ -176,6 +187,7 @@ set(MEPHIT_LIBS
   hdf5::hdf5_fortran
   hdf5::hdf5_hl_fortran
   GSL::gsl
+  fortnum
   BLAS::BLAS
   LAPACK::LAPACK
   ${FFTW_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ include(FetchContent)
 if(NOT TARGET fortnum)
   FetchContent_Declare(fortnum
     GIT_REPOSITORY https://github.com/lazy-fortran/fortnum.git
-    GIT_TAG a7faa3c
+    GIT_TAG v0.1.0
   )
   FetchContent_MakeAvailable(fortnum)
 endif()

--- a/src/hyper1F1.c
+++ b/src/hyper1F1.c
@@ -3,13 +3,12 @@
   Both Kummer series and continued fractions are used.
 */
 
+#include <float.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <gsl/gsl_errno.h>
-#include <gsl/gsl_integration.h>
-#include <gsl/gsl_sum.h>
+#include "fortnum.h"
 
 #include "hyper1F1.h"
 
@@ -51,30 +50,18 @@ void hypergeometric1f1_quad(double *b_re, double *b_im,
                             double *f_re, double *f_im)
 {
   // computes function 1F1(a,b,z) for a = 1 and complex b & z by quadrature
-  // must be optimized: avoid memory allocation!
-
-  gsl_set_error_handler_off();
 
   complex_double b = CMPLX(*b_re, *b_im), z = CMPLX(*z_re, *z_im);
 
-  size_t limit = 100;
   double epsabs = 1.0e-12, epsrel = 1.0e-12, err;
-
-  gsl_integration_workspace *w = gsl_integration_workspace_alloc(limit);
 
   struct quad_params qp = {b, z, 0};
 
-  gsl_function F;
-  F.function = &exp1mt;
-  F.params = &qp;
-
   qp.part = 0;
-  gsl_integration_qag(&F, 0.0, 1.0, epsabs, epsrel, limit, GSL_INTEG_GAUSS21, w, f_re, &err);
+  fortnum_integrate_qag(&exp1mt, 0.0, 1.0, epsabs, epsrel, 21, f_re, &err, &qp);
 
   qp.part = 1;
-  gsl_integration_qag(&F, 0.0, 1.0, epsabs, epsrel, limit, GSL_INTEG_GAUSS21, w, f_im, &err);
-
-  gsl_integration_workspace_free(w);
+  fortnum_integrate_qag(&exp1mt, 0.0, 1.0, epsabs, epsrel, 21, f_im, &err, &qp);
 }
 
 /*******************************************************************/
@@ -305,23 +292,19 @@ void hypergeometric1f1_kummer_modified_0_accel(double *b_re, double *b_im,
     t_im[n] = cimag(term[n]);
   }
 
-  gsl_sum_levin_u_workspace *w = gsl_sum_levin_u_alloc((size_t) N);
-
   double err;
 
-  gsl_sum_levin_u_accel(t_re, (size_t) N, w, f_re, &err);
+  fortnum_levin_u_accel(t_re, N, f_re, &err);
   if (err > 1.0e-16) {
-    fprintf(stdout, "\nerr = %.16le sum_re = %.16le using %ld terms",
-            err, *f_re, w->terms_used);
+    fprintf(stdout, "\nerr = %.16le sum_re = %.16le using %d terms",
+            err, *f_re, N);
   }
 
-  gsl_sum_levin_u_accel(t_im, (size_t) N, w, f_im, &err);
+  fortnum_levin_u_accel(t_im, N, f_im, &err);
   if (err > 1.0e-16) {
-    fprintf(stdout, "\nerr = %.16le sum_im = %.16le using %ld terms",
-            err, *f_im, w->terms_used);
+    fprintf(stdout, "\nerr = %.16le sum_im = %.16le using %d terms",
+            err, *f_im, N);
   }
-
-  gsl_sum_levin_u_free(w);
 }
 
 /*******************************************************************/

--- a/src/mephit_pert.f90
+++ b/src/mephit_pert.f90
@@ -1,7 +1,6 @@
 module mephit_pert
 
   use iso_fortran_env, only: dp => real64
-  use iso_c_binding, only: c_int, c_double
 
   implicit none
 
@@ -35,17 +34,6 @@ module mephit_pert
       type(field_cache_t), intent(in) :: f
       complex(dp) :: vector_element_projection
     end function vector_element_projection
-  end interface
-
-  interface
-    function gsl_sf_bessel_icn_array(nmin, nmax, x, result_array) &
-      bind(C, name='gsl_sf_bessel_In_array')
-      import :: c_int, c_double
-      integer(c_int), intent(in), value :: nmin, nmax
-      real(c_double), intent(in), value :: x
-      real(c_double), intent(inout), dimension(nmax - nmin + 1) :: result_array
-      integer(c_int) :: gsl_sf_bessel_icn_array
-    end function gsl_sf_bessel_icn_array
   end interface
 
   type :: L1_t
@@ -1427,21 +1415,21 @@ contains
   !> field
   subroutine kilca_vacuum_fourier(tor_mode, pol_mode, R_0, r, vac_coeff, &
     B_rad, B_pol, B_tor)
-    use mephit_conf, only: logger
     use mephit_util, only: imun
+    use fortnum_special, only: bessel_in_array
     integer, intent(in) :: tor_mode, pol_mode
     real(dp), intent(in) :: R_0, r
     complex(dp), intent(in) :: vac_coeff
     complex(dp), intent(out) :: B_rad, B_pol, B_tor
-    real(c_double) :: I_m(-1:1), k_z_r
-    integer(c_int) :: status
+    real(dp) :: I_n(0:abs(pol_mode) + 1), I_m(-1:1), k_z_r
 
     k_z_r = tor_mode / R_0 * r
-    status = gsl_sf_bessel_icn_array(abs(pol_mode)-1, abs(pol_mode)+1, k_z_r, I_m)
-    if (status /= 0 .and. logger%err) then
-      write (logger%msg, '("gsl_sf_bessel_In_array returned error ", i0)') status
-      call logger%write_msg
-    end if
+    ! fortnum fills I_n(0:nmax) with I_0..I_nmax; recover the order |pol_mode|-1
+    ! (which is -1 for pol_mode = 0) via the symmetry I_{-n}(x) = I_n(x).
+    call bessel_in_array(abs(pol_mode) + 1, k_z_r, I_n)
+    I_m(-1) = I_n(abs(abs(pol_mode) - 1))
+    I_m(0) = I_n(abs(pol_mode))
+    I_m(1) = I_n(abs(pol_mode) + 1)
     B_rad = 0.5d0 * (I_m(-1) + I_m(1)) * vac_coeff
     B_pol = imun * pol_mode / k_z_r * I_m(0) * vac_coeff
     B_tor = imun * I_m(0) * vac_coeff


### PR DESCRIPTION
## Merge order

Stack sequence: #29 -> #30 -> #31 -> #32 -> #33.

Each PR is now based on main individually, so its diff is cumulative against main and shares code with its stack neighbors. Merge in the sequence above. Once a predecessor merges into main, the next PR rebases onto it and its diff shrinks to its own increment.

---

Second in the fortnum migration stack (base: the Bessel PR). Moves the C confluent-hypergeometric evaluation off GSL.

Dependency removed: GSL adaptive quadrature and Levin u-sum acceleration in src/hyper1F1.c (gsl_integration_qag, gsl_integration_workspace, gsl_set_error_handler_off, gsl_sum_levin_u_*). The boundary integral now uses fortnum_integrate_qag with the Gauss-Kronrod 21 rule, and the Kummer-series acceleration uses fortnum_levin_u_accel. Both fortnum routines take the integrand plus an opaque context, so the existing quad_params struct is forwarded unchanged and no workspace is allocated. float.h is added for DBL_EPSILON, which was previously pulled in transitively through a GSL header.

## Verification

Build the shared library at this tip:

```
$ cmake -S . -B build -G Ninja && cmake --build build --target mephit
[8/9] Building C object CMakeFiles/mephit.dir/src/hyper1F1.c.o
[9/9] Linking CXX shared library lib/libmephit.so
```

No GSL integration or sum symbols remain undefined; fortnum's routines are defined in the library:

```
$ nm -DuC build/lib/libmephit.so | grep -i 'gsl_integration_qag\|gsl_sum_levin\|gsl_integration_workspace'
(no output)
$ nm -DC build/lib/libmephit.so | grep -i 'fortnum_integrate_qag\|fortnum_levin_u'
0000000000115760 T fortnum_integrate_qag
0000000000115830 T fortnum_levin_u_accel
```

The only GSL symbols still referenced belong to the C call sites moved in PR 3 of this stack (glfixed, gsl_strerror). As in PR 1, the .x executables link only after PR 4 removes the empty FFTW link.



Note: fortnum pin updated to current main (92de6e9) after a fortnum history rewrite; old shas no longer resolve.