### PR TITLE
Drop dead names from libneo unexport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BUILD_NINJA := $(BUILD_DIR)/build.ninja
 
 # Prevent ambient shell variables from silently altering which libneo is fetched.
 # unexport stops them reaching cmake via the child environment.
-unexport LIBNEO_REF LIBNEO_PATH LIBNEO_BRANCH LIBNEO_DIR
+unexport LIBNEO_REF LIBNEO_PATH
 
 # Forward only an explicitly passed command-line value, e.g. make LIBNEO_REF=main.
 # $(origin ...) == "command line" only when the user typed it on the make invocation;


### PR DESCRIPTION
The cmake side honors `LIBNEO_REF` and `LIBNEO_PATH`; `LIBNEO_BRANCH` is not read and `LIBNEO_DIR` is a FORCE-set output cache var. Unexport only the two live override names.

## Verification
Before: `unexport` listed `LIBNEO_BRANCH` and `LIBNEO_DIR`, neither consumed as an override.
After: `make -n` parses and emits an identical default cmake line; no behavior change.