### PR TITLE
Register MEPHIT CTest smoke checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 
 ### Define the project
 project(MEPHIT LANGUAGES C CXX Fortran)
+include(CTest)
 
 ### Define options
 option(WITH_MFEM "Compile with MFEM" FALSE)
@@ -217,3 +218,13 @@ configure_file(data/convexwall_kilca.dat ${PROJECT_BINARY_DIR}/data/convexwall_k
 configure_file(data/convexwall_mastu.dat ${PROJECT_BINARY_DIR}/data/convexwall_mastu.dat COPYONLY)
 configure_file(data/field_divB0.inp ${PROJECT_BINARY_DIR}/data/field_divB0.inp COPYONLY)
 configure_file(data/preload_for_SYNCH.inp ${PROJECT_BINARY_DIR}/data/preload_for_SYNCH.inp COPYONLY)
+
+if(BUILD_TESTING)
+  add_test(NAME mephit_cli_help
+    COMMAND ${PROJECT_BINARY_DIR}/scripts/mephit.bash --help)
+  set_tests_properties(mephit_cli_help PROPERTIES
+    PASS_REGULAR_EXPRESSION "README.md")
+  add_test(NAME mephit_requires_config COMMAND mephit_test.x)
+  set_tests_properties(mephit_requires_config PROPERTIES
+    WILL_FAIL TRUE)
+endif()

--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -26,6 +26,8 @@ function(find_or_fetch DEPENDENCY)
     endif()
 
     set(_DEP_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${DEPENDENCY})
+    # Parent CTest enablement must not register unbuilt dependency tests.
+    set(BUILD_TESTING OFF)
     add_subdirectory(${${DEPENDENCY}_SOURCE_DIR}
         ${_DEP_BINARY_DIR}
         EXCLUDE_FROM_ALL


### PR DESCRIPTION
## Summary

Register a nonempty MEPHIT CTest inventory and keep tests from fetched
dependencies out of the parent test suite.

The two self-contained checks exercise public process boundaries:

- `mephit_cli_help` requires the installed helper script's help path to exit
  successfully and direct the user to the README;
- `mephit_requires_config` requires `mephit_test.x` to reject invocation
  without its mandatory configuration file.

`find_or_fetch` temporarily disables `BUILD_TESTING` while adding libneo as a
subdirectory. MEPHIT retains its own `BUILD_TESTING` setting, but it no longer
registers libneo tests whose executables and external fixtures are intentionally
excluded from the consumer build.

This closes #35's false-green condition. It does not claim a numerical MEPHIT
regression suite; numerical fixture coverage remains future test work.

## Build and semantic invariants

- MEPHIT sources, compiler flags, linked libraries, executable interfaces, and
  runtime configuration are unchanged.
- libneo remains fetched at the caller-selected ref and linked through the same
  targets.
- `BUILD_TESTING=OFF` still disables all MEPHIT tests.
- The change affects test registration only; numerical algorithms,
  discretizations, convergence criteria, CGS units, boundary conditions, ABI,
  and memory layout are unchanged.

## Verification

Failing before this change:

```text
$ make test LIBNEO_REF=e451e0a42f5228d85b0479de40aa35db8b48239d
cd build && ctest
No test configuration file found!
$ echo $?
0

$ fo test
Tests: 0 passed (0.00s)
```

After initially enabling parent CTest but before isolating dependency tests,
`fo test` registered 97 tests and failed on unbuilt libneo executables. This
guards the dependency boundary as well as the empty-suite case.

Passing after both changes:

```text
$ fo
Static: OK (115 modules, 115 changed, 115 affected)
Build: OK
Tests: OK
Lint: OK
All stages passed

$ fo test
Tests: 2 passed (0.2s)

$ make test LIBNEO_REF=e451e0a42f5228d85b0479de40aa35db8b48239d
1/2 Test #1: mephit_cli_help ........... Passed
2/2 Test #2: mephit_requires_config .... Passed
100% tests passed, 0 tests failed out of 2
```
