### PR TITLE
build: fetch dependency commits that no clone can reach

### DIFF
--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -1,4 +1,59 @@
 include(FetchContent)
+find_package(Git REQUIRED)
+
+# Populate DEST with REPO_URL at REF for refs a plain clone cannot reach.
+#
+# FetchContent clones the whole repository and then runs `git checkout <ref>`.
+# A clone only carries objects reachable from a branch or tag, so a bare commit
+# SHA whose branch has been deleted -- exactly what the downstream libneo gate
+# passes via LIBNEO_REF for a merged or fork pull request -- is absent from the
+# clone and the checkout dies with "unable to read tree (<sha>)". Fetching the
+# commit by name instead works, because GitHub serves fetch-by-SHA requests.
+function(fetch_git_ref DEPENDENCY REPO_URL REF DEST)
+    if(EXISTS "${DEST}/.git")
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+            WORKING_DIRECTORY ${DEST}
+            OUTPUT_VARIABLE _HEAD_SHA
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            RESULT_VARIABLE _RESULT
+            ERROR_QUIET
+        )
+        if(_RESULT EQUAL 0 AND _HEAD_SHA STREQUAL "${REF}")
+            message(STATUS "Reusing ${DEPENDENCY} checkout at ${REF} in ${DEST}")
+            return()
+        endif()
+    endif()
+
+    file(REMOVE_RECURSE ${DEST})
+    file(MAKE_DIRECTORY ${DEST})
+    _run_git_step(${DEST} "initialise ${DEPENDENCY} repository" init --quiet)
+    _run_git_step(${DEST} "add ${DEPENDENCY} remote" remote add origin ${REPO_URL})
+    _run_git_step(${DEST} "fetch ${DEPENDENCY} ref ${REF} from ${REPO_URL}"
+        fetch --quiet --depth 1 origin ${REF})
+    _run_git_step(${DEST} "check out ${DEPENDENCY} ref ${REF}"
+        checkout --quiet --detach FETCH_HEAD)
+endfunction()
+
+
+function(_run_git_step WORK_DIR WHAT)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} ${ARGN}
+        WORKING_DIRECTORY ${WORK_DIR}
+        RESULT_VARIABLE _RESULT
+        ERROR_VARIABLE _STDERR
+    )
+    if(NOT _RESULT EQUAL 0)
+        message(FATAL_ERROR
+            "Failed to ${WHAT}.\n"
+            "git ${ARGN} exited with ${_RESULT}:\n${_STDERR}\n"
+            "The ref must exist in the remote repository; a commit that was "
+            "never pushed, or a pull request head from a private fork, cannot "
+            "be fetched."
+        )
+    endif()
+endfunction()
+
 
 function(find_or_fetch DEPENDENCY)
     string(TOUPPER ${DEPENDENCY} _DEP_UPPER)
@@ -16,13 +71,30 @@ function(find_or_fetch DEPENDENCY)
         endif()
         message(STATUS "Using ${DEPENDENCY} ref ${REMOTE_BRANCH} from ${REPO_URL}")
 
-        FetchContent_Declare(
-            ${DEPENDENCY}
-            DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-            GIT_REPOSITORY ${REPO_URL}
-            GIT_TAG ${REMOTE_BRANCH}
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} ls-remote --heads --tags ${REPO_URL} ${REMOTE_BRANCH}
+            OUTPUT_VARIABLE REF_ON_REMOTE
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
         )
-        FetchContent_Populate(${DEPENDENCY})
+        if(REF_ON_REMOTE)
+            FetchContent_Declare(
+                ${DEPENDENCY}
+                DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+                GIT_REPOSITORY ${REPO_URL}
+                GIT_TAG ${REMOTE_BRANCH}
+            )
+            FetchContent_Populate(${DEPENDENCY})
+        else()
+            # No branch or tag points at this ref, so a clone would not contain
+            # it. Fetch the commit directly instead. See fetch_git_ref above.
+            message(STATUS
+                "${DEPENDENCY} ref ${REMOTE_BRANCH} is not a branch or tag; "
+                "fetching the commit directly")
+            set(${DEPENDENCY}_SOURCE_DIR ${FETCHCONTENT_BASE_DIR}/${DEPENDENCY}-src)
+            fetch_git_ref(${DEPENDENCY} ${REPO_URL} ${REMOTE_BRANCH}
+                ${${DEPENDENCY}_SOURCE_DIR})
+        endif()
     endif()
 
     set(_DEP_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${DEPENDENCY})


### PR DESCRIPTION
## Root cause

`cmake/Util.cmake` populates libneo through `FetchContent`, which runs `git clone` and then `git checkout <ref>`. A clone only carries objects reachable from a branch or tag, so a **bare commit SHA that no branch points at** is simply not in the cloned repository and the checkout dies with:

```
fatal: unable to read tree (dcc8a482c557d638611291150066c4d722c69aa5)
CMake Error ... Failed to checkout tag: 'dcc8a482...'
```

Two ways MEPHIT hits this:

1. **libneo's downstream gate** dispatches MEPHIT CI with `libneo_ref` set to a libneo PR head SHA. Once that PR is merged and its branch auto-deleted (or if the PR comes from a fork), the SHA lives only under `refs/pull/*` and the clone cannot reach it. This is exactly run [31108105039](https://github.com/itpplasma/MEPHIT/actions/runs/31108105039), dispatched with `dcc8a482` from the now-deleted `fix/geqdsk-ray-root-convergence`.
2. **MEPHIT's own default pin.** `cmake/SetupCODE.cmake` pins `LIBNEO_REF=f3f241dea2c7dc25cf29731bb0a1328ff98f48c8`. That SHA is currently reachable *only* from the unrelated agent branch `agent/geoflux-axis-limit`. When that branch is deleted, every ordinary push and pull-request build of `main` breaks in configure. This is a live time bomb, not a hypothetical.

## Evidence that this is environmental, not a code regression

MEPHIT `main` at commit `f296cd1b` succeeded four times on 2026-07-30, failed on 07-31 and 08-06, and succeeded again today (run [31373795316](https://github.com/itpplasma/MEPHIT/actions/runs/31373795316), 2026-08-10). Same MEPHIT commit, different outcomes — the variable is which libneo ref was passed in and whether it was still reachable from a branch at build time.

I reproduced the clone failure exactly, outside CI:

```console
$ git clone --no-checkout --config advice.detachedHead=false \
      https://github.com/itpplasma/libneo.git libneo-src
Cloning into 'libneo-src'...
$ cd libneo-src && git checkout dcc8a482c557d638611291150066c4d722c69aa5 --
fatal: unable to read tree (dcc8a482c557d638611291150066c4d722c69aa5)
```

and confirmed that fetching the commit by name works, because GitHub serves fetch-by-SHA:

```console
$ git fetch --depth 1 origin dcc8a482c557d638611291150066c4d722c69aa5
 * branch  dcc8a482... -> FETCH_HEAD
$ git checkout --detach FETCH_HEAD   # succeeds
```

## What changed

`cmake/Util.cmake` only:

- Resolve the requested ref against the remote with `git ls-remote --heads --tags`. If it is a branch or tag, the existing `FetchContent` path runs **unchanged**.
- Otherwise populate `_deps/<dep>-src` directly with `git init` + `git remote add` + `git fetch --depth 1 origin <ref>` + `git checkout --detach FETCH_HEAD`. Idempotent: a re-configure with the same SHA reuses the existing checkout instead of re-cloning.
- Failures now report which step failed, the ref, and git's own stderr, instead of a raw `FetchContent` stack trace.

No pinning of the runner image and no workflow changes were needed — the runner image was identical (`ubuntu-24.04` `20260720.247.2`) across the green and red runs, so image drift was never the cause.

## The other failure mode (run 30657820508) — already fixed upstream, deliberately not touched here

Run [30657820508](https://github.com/itpplasma/MEPHIT/actions/runs/30657820508) failed differently:

```
Fatal Error: Cannot open module file 'netcdf.mod' for reading
```

That run was dispatched with libneo `d2bbe531` (head of libneo PR #408). At that point libneo's `cmake/DetectDependencies.cmake` reported `NetCDF-Fortran not found on system (nf-config missing)`, built NetCDF-C 4.9.2 and NetCDF-Fortran 4.6.1 from source, and did not propagate the generated Fortran module directory to consumers. libneo PR #407 ("Replace NetCDF and HDF5 dependencies with fortio") has since removed `DetectDependencies.cmake` entirely, and `netcdf.mod` now comes from fortio. Today's green run on the identical MEPHIT commit confirms it. I therefore made **no** NetCDF change in MEPHIT: MEPHIT has no NetCDF `find_package` of its own, and injecting a system `nf-config` include directory would risk mixing a system `netcdf.mod` with the fortio-provided library. If this recurs, the fix belongs in libneo.

## Verified

Locally, with CMake 3.31.6 (same major/minor as CI) and GNU Fortran:

- Reproduced the original clone failure verbatim (above).
- Unit-tested `fetch_git_ref` in CMake script mode against `dcc8a482`: fetch + checkout succeed; a second run reuses the checkout; a nonexistent SHA fails with the new explanatory message.
- **Full configure and build** of MEPHIT with `-DLIBNEO_REF=137ded915cedd6e7247f9e00cac03e6d2d9cef9b` (a bare SHA, taking the new path): `ninja` completed all 380 targets, producing `mephit_run.x`, `mephit_test.x`, `mephit_post.x` and `libmephit.so`. `src/mephit_mesh.F90` and `src/mephit_pert.f90`, the two files that `use netcdf`, compiled cleanly.
- Regression check that the unchanged path stays unchanged: `-DLIBNEO_REF=main` configures successfully and still goes through `FetchContent` (`_deps/libneo-subbuild` present, no "not a branch or tag" message).

## Not verified

- I did not run `ctest`; the local build was a build-only check, matching what this workflow does.
- I could not test a pull-request head from a **private** fork; GitHub will refuse the fetch there and the build will stop with the new explanatory error rather than a stack trace, which is the intended behaviour but is untested against a real private fork.
- The stale `LIBNEO_REF` pin in `cmake/SetupCODE.cmake` is left as is. This PR makes the pin work regardless of branch reachability, but bumping it to a current libneo commit is a separate decision.

## Downstream

This unblocks libneo's `gate` check, where MEPHIT is the only red repo, for libneo PRs #408 and #410 and for every future gate run that passes a merged or fork PR head as `LIBNEO_REF`.
