### PR TITLE
Dump the outer-boundary input next to outer.msh

### DIFF
--- a/src/mephit_mesh.F90
+++ b/src/mephit_mesh.F90
@@ -3108,6 +3108,17 @@ contains
     theta(:) = linspace(0d0, 2d0 * pi, npt_outer, 0, 1)
     bdry_R(npt_inner+1:) = R_mid + R_rad * cos(theta)
     bdry_Z(npt_inner+1:) = Z_mid + Z_rad * sin(theta)
+    ! dump the triangulator input so the annulus meshing problem can be
+    ! reproduced without a MEPHIT build, e.g. for mesher comparisons
+    open(newunit = fid, file = decorate_filename('outer_boundary.dat', '', basename_suffix), &
+      status = 'replace', form = 'formatted', action = 'write')
+    write (fid, '(2(1x, i0))') npt_inner, npt_outer
+    ! 17 significant digits so the dump round-trips the double precision input
+    write (fid, '(2(1x, es24.16e3))') R_mid, Z_mid
+    do kpoi = 1, npt_inner + npt_outer
+      write (fid, '(2(1x, es24.16e3))') bdry_R(kpoi), bdry_Z(kpoi)
+    end do
+    close(fid)
     call FEM_triangulate_external(npt_inner, npt_outer, bdry_R, bdry_Z, R_mid, Z_mid, &
       decorate_filename('outer.msh', '', basename_suffix) // c_null_char)
     deallocate(bdry_R, bdry_Z, theta)


### PR DESCRIPTION
`write_FreeFem_mesh` writes the mesh Triangle produces but not the input Triangle was given, so reproducing the annulus meshing problem outside MEPHIT requires a MEPHIT build. That is why both Triangle-replacement experiments so far (#27, #40) were judged on a hand-made circle rather than a real boundary.

This writes `outer_boundary.dat` next to `outer.msh` on every meshing run:

```
npt_inner npt_outer
R_hole Z_hole
R Z                    x (npt_inner + npt_outer)
```

17 significant digits, so the dump round-trips the double precision input. A shorter format is not neutral: truncating at 16 digits moves the `TCFP_hip` production case from 2470 to 2472 triangles, because the KiLCA cases sit at `R ~ 1.7e5 cm` with 0.5 cm edges.

Eleven lines, one extra ~45 kB text file per run, no behaviour change.

### What it enabled

Dumps from this branch now drive https://github.com/krystophny/tokamak-annulus-mesh-bench, which runs fortfem's `triangle_compat`, Delaunay32 and Triangle on the same `.msh` contract with no MEPHIT build. Measured on real boundaries from `data/mephit_g000001.0001_TCFP_hip.in` at `max_Delta_rad` 3.0 / 1.0 / 0.45 cm:

| case | inner pts | fortfem tris | Triangle tris | fortfem min angle | Triangle min angle |
|---|---|---|---|---|---|
| coarse | 126 | 366 | 366 | 20.122° | 20.122° |
| medium | 366 | 1048 | 1048 | 20.152° | 20.152° |
| production | 814 | 2470 | 2470 | 20.060° | 20.060° |

fortfem matches Triangle exactly on all three. Delaunay32 preserves topology and area but, having no Steiner refinement, drops from 2.56° at 126 boundary points to 0.44° at 814 — the 128-point fixture in #40 overstated it by about a factor of six.

Relates to #25.

https://claude.ai/code/session_01ReV3pqLhWXFrM5DsrcSgWL